### PR TITLE
chore: Add  yarn cache option in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - '11.10.1'
+cache: yarn


### PR DESCRIPTION
This will cache all the dependencies so travis tests will run faster.

https://docs.travis-ci.com/user/caching/#yarn-cache