### PR TITLE
Add production build scripts on server

### DIFF
--- a/server/__tests__/env/expressEnvironment.js
+++ b/server/__tests__/env/expressEnvironment.js
@@ -1,5 +1,5 @@
 import NodeEnvironment from 'jest-environment-node';
-import { createTestServer } from '../../src/utils/testUtils';
+import { createTestServer } from '../testUtils';
 
 class ExpressEnvironment extends NodeEnvironment {
   async setup() {

--- a/server/__tests__/leaderboardAPI.test.js
+++ b/server/__tests__/leaderboardAPI.test.js
@@ -4,7 +4,7 @@ import {
   getMockPlayers,
   sortPlayersAndGetTop,
   seedDatabase,
-} from '../src/utils/testUtils';
+} from './testUtils';
 import { generateJWT } from '../src/utils/encryptUtils';
 
 const { testServer } = global;

--- a/server/__tests__/loginAPI.test.js
+++ b/server/__tests__/loginAPI.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import request from 'supertest';
-import { getMockUser } from '../src/utils/testUtils';
+import { getMockUser } from './testUtils';
 
 let mockUser;
 

--- a/server/__tests__/setup/globalSetup.js
+++ b/server/__tests__/setup/globalSetup.js
@@ -1,4 +1,4 @@
-const { createMockgoose } = require('../../src/utils/testUtils');
+const { createMockgoose } = require('../testUtils');
 
 module.exports = async () => {
   global.MOCKGOOSE = await createMockgoose();

--- a/server/__tests__/signupAPI.test.js
+++ b/server/__tests__/signupAPI.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import request from 'supertest';
-import { getMockUser } from '../src/utils/testUtils';
+import { getMockUser } from './testUtils';
 
 let mockUser;
 

--- a/server/__tests__/testUtils.js
+++ b/server/__tests__/testUtils.js
@@ -1,13 +1,13 @@
 import mongoose from 'mongoose';
 import { Mockgoose } from 'mockgoose';
-import app from '../app/app';
+import app from '../src/app/app';
 import {
   TEST_PORT,
   DB_URL,
   LEADERBOARD_LIMIT,
-} from '../app/appConstants';
-import mongoConfig from '../database/mongoConfig';
-import { generateJWT } from './encryptUtils';
+} from '../src/app/appConstants';
+import mongoConfig from '../src/database/mongoConfig';
+import { generateJWT } from '../src/utils/encryptUtils';
 
 export const getMockUser = () => {
   const testUser = (Math.random() * 10000).toFixed(0);

--- a/server/__tests__/validateAPI.test.js
+++ b/server/__tests__/validateAPI.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import request from 'supertest';
-import { getMockUser } from '../src/utils/testUtils';
+import { getMockUser } from './testUtils';
 
 const { testServer } = global;
 let JWT;

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>jest.setup.js'],
   globalSetup: '<rootDir>/__tests__/setup/globalSetup.js',
   globalTeardown: '<rootDir>/__tests__/setup/globalTeardown.js',
-  testPathIgnorePatterns: ['/__tests__/env/', '/__tests__/setup/'],
+  testPathIgnorePatterns: ['/__tests__/env/', '/__tests__/setup/', 'testUtils.js'],
 };

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "Backend for rattle-battle",
   "main": "index.js",
   "scripts": {
-    "start": "babel-node src",
+    "build": "rm -rf build && babel src -d build --source-maps",
+    "start": "node build/index.js",
     "start:dev": "nodemon --exec babel-node src",
     "lint": "npx eslint src",
     "test": "jest --runInBand"
@@ -13,23 +14,24 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
     "bcrypt": "^3.0.4",
     "body-parser": "^1.18.3",
-    "chai": "^4.2.0",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "dotenv-parse-variables": "^0.2.0",
-    "esm": "^3.2.5",
     "express": "^4.16.4",
     "express-jwt": "^5.3.1",
     "express-validator": "^5.3.1",
     "jsonwebtoken": "^8.5.0",
-    "mockgoose": "^8.0.1",
     "mongoose": "^5.4.14",
     "socket.io": "^2.2.0"
   },
   "devDependencies": {
+    "@babel/polyfill": "^7.2.5",
+    "mockgoose": "^8.0.1",
+    "esm": "^3.2.5",
+    "chai": "^4.2.0",
+    "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.3",
     "@babel/node": "^7.2.2",
     "@babel/preset-env": "^7.3.1",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,6 +2,23 @@
 # yarn lockfile v1
 
 
+"@babel/cli@^7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.2.3.tgz#1b262e42a3e959d28ab3d205ba2718e1923cfee6"
+  integrity sha512-bfna97nmJV6nDJhXNPeEfxyMjWnt6+IjUAaDPiYRTBlm8L41n8nvw6UAqUCbvpFfU246gHPxW7sfWwqtF4FcYA==
+  dependencies:
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    output-file-sync "^2.0.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.0.3"
+
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -1274,7 +1291,7 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-chokidar@^2.1.0:
+chokidar@^2.0.3, chokidar@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
   integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
@@ -2484,6 +2501,11 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2578,7 +2600,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -3076,6 +3098,11 @@ is-path-inside@^1.0.0:
   integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -4537,6 +4564,15 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
+  integrity sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    is-plain-obj "^1.1.0"
+    mkdirp "^0.5.1"
 
 p-defer@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
resolves #77 

Add script that creates a production build which we can
deploy on the server since babel-node is not meant to be
used in production.

Also, moved all testing dependencies and utils to
dev-dependencies so they don't come up on the production server.

Also, moved `testUtils.js` in `__tests__` folder so it doesn't come up in production build. 
