### PR TITLE
chore: Deploy client on now.sh

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "now-build": "react-scripts build",
     "test": "react-scripts test --testPathIgnorePatterns testUtils.js",
     "eject": "react-scripts eject",
     "lint": "npx eslint ./src"

--- a/now.json
+++ b/now.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "name": "rattle-battle",
+  "builds": [
+    {
+      "src": "client/package.json",
+      "use": "@now/static-build",
+      "config": { "distDir": "build" }
+    }
+  ],
+  "routes": [
+    {
+      "src": "^/static/(.*)",
+      "headers": { "cache-control": "s-maxage=31536000,immutable" },
+      "dest": "client/static/$1"
+    },
+    { "src": "^/favicon.ico", "dest": "client/favicon.ico" },
+    { "src": "^/asset-manifest.json", "dest": "client/asset-manifest.json" },
+    { "src": "^/manifest.json", "dest": "client/manifest.json" },
+    {
+      "src": "^/precache-manifest.(.*)",
+      "dest": "client/precache-manifest.$1"
+    },
+    {
+      "src": "^/(.*)",
+      "headers": { "cache-control": "s-maxage=0" },
+      "dest": "client/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Client successfully deployed to https://rattle-battle.now.sh/