### PR TITLE
chore: add linting in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - '11.10.1'
 cache: yarn
+before_script: yarn lint


### PR DESCRIPTION
**Why?**

We already have a pre-commit hook which checks for linting errors before every commit. But sometimes it doesn't work so this is an extra step to catch these kinds of errors early. 

Let me know what you think.